### PR TITLE
`goto` slide

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -103,12 +103,29 @@ export function goto(lineNumber) {
 export function gosub(lineNumber) {
     expectParameters(lineNumber);
 
+    var labels = Object.keys(basic.programLabels);
+
+    for (var i = 0; i < labels.length; i++) {
+        if (!Number.isNaN(Number(labels[i]))) {
+            if (Number(labels[i]) >= Number(lineNumber.value)) {
+                basic.pushStack(lineNumber.lineNumber);
+                basic.executeStatement(basic.programLabels[labels[i]]);
+
+                return;
+            }
+        }
+
+        if (labels[i] == lineNumber.value) { // Here if we end up adding textual labels
+        basic.pushStack(lineNumber.lineNumber);
+        basic.executeStatement(basic.programLabels[lineNumber.value]);
+
+            return;
+        }
+    }
+
     if (!basic.programLabels.hasOwnProperty(lineNumber.value)) {
         throw new basic.RuntimeError(`Cannot gosub to nonexistent line ${lineNumber.value}`, lineNumber.lineNumber);
     }
-
-    basic.pushStack(lineNumber.lineNumber);
-    basic.executeStatement(basic.programLabels[lineNumber.value]);
 }
 
 export function returnFromSub() {

--- a/commands.js
+++ b/commands.js
@@ -77,11 +77,27 @@ export function assign(identifier, value) {
 export function goto(lineNumber) {
     expectParameters(lineNumber);
 
+    var labels = Object.keys(basic.programLabels);
+
+    for (var i = 0; i < labels.length; i++) {
+        if (!Number.isNaN(Number(labels[i]))) {
+            if (Number(labels[i]) >= Number(lineNumber.value)) {
+                basic.executeStatement(basic.programLabels[labels[i]]);
+
+                return;
+            }
+        }
+
+        if (labels[i] == lineNumber.value) { // Here if we end up adding textual labels
+            basic.executeStatement(basic.programLabels[lineNumber.value]);
+
+            return;
+        }
+    }
+
     if (!basic.programLabels.hasOwnProperty(lineNumber.value)) {
         throw new basic.RuntimeError(`Cannot goto nonexistent line ${lineNumber.value}`, lineNumber.lineNumber);
     }
-
-    basic.executeStatement(basic.programLabels[lineNumber.value]);
 }
 
 export function gosub(lineNumber) {

--- a/commands.js
+++ b/commands.js
@@ -116,8 +116,8 @@ export function gosub(lineNumber) {
         }
 
         if (labels[i] == lineNumber.value) { // Here if we end up adding textual labels
-        basic.pushStack(lineNumber.lineNumber);
-        basic.executeStatement(basic.programLabels[lineNumber.value]);
+            basic.pushStack(lineNumber.lineNumber);
+            basic.executeStatement(basic.programLabels[lineNumber.value]);
 
             return;
         }


### PR DESCRIPTION
Implement a `goto` slide (similarly named after the [NOP slide](https://en.wikipedia.org/wiki/NOP_slide)) where if an invalid line number is used in a `goto` or `gosub` statement, then the interpreter will attempt to seek to the next available line after the given line number. An error will still be raised if no next line number is available (ie. the given line number is higher than the number of lines in the program).

See issue #4 for more details and an example program.