### PR TITLE
Fix input lag for Firefox (and Chrome, to a lesser extent)

### DIFF
--- a/hid.js
+++ b/hid.js
@@ -375,7 +375,7 @@ canvas.onReady(function() {
     hidInput.addEventListener("keydown", function(event) {
         setTimeout(function() {
             dispatchInputEvent(event);
-        });
+        }, 10);
     });
 
     renderLoop();


### PR DESCRIPTION
For issue #6. A bit of a bodge (simply just setting the input event timeout to trigger after 10 ms rather than immediately), but it seems to now be significantly less laggy. The original issue was down to the timings at which the renderer renders the contents of `hidInput`, but now, the renderer will only render after enough time has elapsed for the value of `hidInput` to be updated.