### PR TITLE
Auto-expand `details` in popout

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -40,6 +40,12 @@ function visitDocumentation(path) {
             }
         });
 
+        if (window.inDocsPopout) {
+            document.querySelectorAll("details").forEach(function(element) {
+                element.open = true;
+            });
+        }
+
         oldTweet = null;
     });
 }

--- a/style.css
+++ b/style.css
@@ -382,7 +382,7 @@ h1.reference a.comparators {
     overflow: auto;
 }
 
-#docs #docsContent > *:first-child {
+#docs #docsContent > *:not(.popoutOnly):first-of-type {
     margin-top: 0;
 }
 


### PR DESCRIPTION
When printing off our popout docs, some pages might have their `details` elements collapsed, which might not be handy if important information is hidden. For popout docs, all `details` elements will be automatically expanded to mitigate this problem.