### PR TITLE
Dark mode

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -258,10 +258,10 @@ export function init() {
 
     resize();
 
-    setColour(new Colour(238, 238, 238));
+    setColour(colourScheme[COLOUR_NAMES[theme.isDarkMode() ? "black" : "lightgrey"]]);
     clear();
 
-    setColour(new Colour(0, 0, 0));
+    setColour(colourScheme[COLOUR_NAMES[theme.isDarkMode() ? "white" : "black"]]);
     setStrokeWidth(1);
 
     resetStrokeWidth();

--- a/commands.js
+++ b/commands.js
@@ -4,6 +4,7 @@ import * as canvas from "./canvas.js";
 import * as term from "./term.js";
 import * as hid from "./hid.js";
 import * as audio from "./audio.js";
+import * as theme from "./theme.js";
 
 export var keywords = {
     "print": print,
@@ -340,7 +341,7 @@ export function delay(milliseconds) {
 }
 
 export function setBackgroundColour(mode, p1, p2, p3, alpha) {
-    var chosenMode = String(mode != undefined ? mode.value : "grey").toLocaleLowerCase();
+    var chosenMode = String(mode != undefined ? mode.value : (theme.isDarkMode() ? "black" : "grey")).toLocaleLowerCase();
 
     if (canvas.COLOUR_NAMES.hasOwnProperty(chosenMode)) {
         term.background(chosenMode);
@@ -370,7 +371,7 @@ export function setBackgroundColour(mode, p1, p2, p3, alpha) {
 }
 
 export function setForegroundColour(mode, p1, p2, p3, alpha) {
-    var chosenMode = String(mode != undefined ? mode.value : "black").toLocaleLowerCase();
+    var chosenMode = String(mode != undefined ? mode.value : (theme.isDarkMode() ? "white" : "black")).toLocaleLowerCase();
 
     if (canvas.COLOUR_NAMES.hasOwnProperty(chosenMode)) {
         term.foreground(chosenMode);

--- a/style.css
+++ b/style.css
@@ -15,6 +15,8 @@
     --pink: rgb(255, 71, 191);
     --yellow: rgb(252, 218, 63);
     --white: rgb(255, 255, 255);
+
+    --almostBlack: rgb(16, 16, 16);
 }
 
 * {
@@ -29,6 +31,13 @@ body {
     background-color: var(--white);
     color: var(--black);
     -webkit-print-color-adjust: exact;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: var(--almostBlack);
+        color: var(--white);
+    }
 }
 
 body.fullscreen {
@@ -53,6 +62,12 @@ canvas {
     position: absolute;
     background-color: #eeeeee;
     border-radius: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+    canvas {
+        background-color: var(--black);
+    }
 }
 
 body.fullscreen canvas {

--- a/term.js
+++ b/term.js
@@ -1,18 +1,22 @@
+import * as theme from "./theme.js";
 import * as canvas from "./canvas.js";
 import * as hid from "./hid.js";
 
-export var backgroundColour = canvas.colourScheme[canvas.COLOUR_NAMES.lightgrey];
-export var foregroundColour = canvas.colourScheme[canvas.COLOUR_NAMES.black];
+const defaultBackgroundColourName = theme.isDarkMode() ? "black" : "lightgrey";
+const defaultForegroundColourName = theme.isDarkMode() ? "white" : "black";
+
+export var backgroundColour = canvas.colourScheme[canvas.COLOUR_NAMES[defaultBackgroundColourName]];
+export var foregroundColour = canvas.colourScheme[canvas.COLOUR_NAMES[defaultForegroundColourName]];
 
 export var col = 0;
 export var row = 0;
 export var scrollDelta = 0;
 
-export function background(colourName = "lightgrey") {
+export function background(colourName = defaultBackgroundColourName) {
     backgroundColour = canvas.colourScheme[canvas.COLOUR_NAMES[colourName]];
 }
 
-export function foreground(colourName = "black") {
+export function foreground(colourName = defaultForegroundColourName) {
     foregroundColour = canvas.colourScheme[canvas.COLOUR_NAMES[colourName]];
 }
 

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,9 @@
+function detectIsDarkMode() {
+    return (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+}
+
+const IS_DARK_MODE = detectIsDarkMode();
+
+export function isDarkMode() {
+    return IS_DARK_MODE;
+}


### PR DESCRIPTION
Implement a simple dark mode theme.

* Auto-detection happens once on startup using a media query
* Changed the absolute minimum amount of code

Further possible enhancements:

* Move all color definitions to the new `theme.js`
* Export default background and default foreground colors from `theme.js`
* (Maybe) replace media query with toggle button and use localStorage to remember choice

*Note:* Feel free to make any changes you like or even reject the PR. I just went ahead and implemented it for my use case as I saw best. Thanks for `atto`!