### PR TITLE
Expressions overhaul

### DIFF
--- a/basic.js
+++ b/basic.js
@@ -598,6 +598,8 @@ export function setVariable(identifierName, value, lineNumber = null) {
 }
 
 export function setConstants() {
+    setVariable("true", 1);
+    setVariable("false", 0);
     setVariable("pi", Math.PI);
     setVariable("e", Math.E);
     setVariable("phi", (1 + Math.sqrt(5)) / 2);

--- a/basic.js
+++ b/basic.js
@@ -225,7 +225,7 @@ export function parseProgram(program) {
 
             identifier = tokens[i];
 
-            expect(++i, (x) => x instanceof syntax.Comparator && x.code == "=");
+            expect(++i, (x) => x instanceof syntax.Assignment);
             expect(++i, (x) => x instanceof syntax.Expression);
 
             start = tokens[i];

--- a/basic.js
+++ b/basic.js
@@ -70,125 +70,6 @@ export class OpeningCommand extends Command {}
 
 export class ClosingCommand extends Command {}
 
-export class Condition {
-    constructor(a, b, comparison) {
-        this.a = a;
-        this.b = b;
-        this.comparison = comparison;
-    }
-
-    get value() {
-        switch (this.comparison.code) {
-            case "=": return getValueComparative(this.a.value) == getValueComparative(this.b.value);
-            case "<": return getValueComparative(this.a.value) < getValueComparative(this.b.value);
-            case ">": return getValueComparative(this.a.value) > getValueComparative(this.b.value);
-            case "<=": return getValueComparative(this.a.value) <= getValueComparative(this.b.value);
-            case ">=": return getValueComparative(this.a.value) >= getValueComparative(this.b.value);
-            case "!=": return getValueComparative(this.a.value) != getValueComparative(this.b.value);
-        }
-    }
-}
-
-export class LogicalOperatorCondition {
-    constructor(conditions, logicalOperator = null, childLogicalOperatorClass = null) {
-        this.conditions = conditions;
-        this.logicalOperator = logicalOperator;
-        this.childLogicalOperatorClass = childLogicalOperatorClass;
-
-        this.children = [];
-    }
-
-    parse() {
-        if (this.logicalOperator == null) {
-            this.children = [];
-
-            return; // This is a leaf logical operator condition
-        }
-
-        this.children = [new this.childLogicalOperatorClass([])];
-
-        for (var i = 0; i < this.conditions.length; i++) {
-            if (this.conditions[i] instanceof syntax.LogicalOperator && this.conditions[i].code == this.logicalOperator.code) {
-                this.children.push(new this.childLogicalOperatorClass([]));
-            } else {
-                this.children[this.children.length - 1].conditions.push(this.conditions[i]);
-            }
-        }
-
-        this.children.forEach((i) => i.parse());
-    }
-
-    get value() {
-        if (this.logicalOperator == null) {
-            return this.conditions[0].value;
-        }
-
-        var value = this.children[0].value;
-
-        for (var i = 1; i < this.children.length; i++) {
-            value = this.reduce(value, this.children[i].value);
-        }
-
-        return value;
-    }
-}
-
-export class LogicalNot extends LogicalOperatorCondition {
-    constructor(conditions) {
-        super(conditions, new syntax.LogicalOperator("not"), LogicalAnd);
-    }
-
-    reduce(a, b) {
-        return !b;
-    }
-}
-
-export class LogicalAnd extends LogicalOperatorCondition {
-    constructor(conditions) {
-        super(conditions, new syntax.LogicalOperator("and"), LogicalOr);
-    }
-
-    reduce(a, b) {
-        return a && b;
-    }
-}
-
-export class LogicalOr extends LogicalOperatorCondition {
-    constructor(conditions) {
-        super(conditions, new syntax.LogicalOperator("or"), LogicalXor);
-    }
-
-    reduce(a, b) {
-        return a || b;
-    }
-}
-
-export class LogicalXor extends LogicalOperatorCondition {
-    constructor(conditions) {
-        super(conditions, new syntax.LogicalOperator("xor"), LogicalLeaf);
-    }
-
-    reduce(a, b) {
-        return a != b;
-    }
-}
-
-export class LogicalLeaf extends LogicalOperatorCondition {
-    constructor(conditions) {
-        super(conditions);
-    }
-
-    get value() {
-        if (this.childLogicalOperatorClass == null) {
-            if (this.conditions.length == 0) {
-                return false;
-            }
-
-            return this.conditions[0].value;
-        }
-    }
-}
- 
 export function trigModeToRadians(value, mode = trigMode) {
     if (mode == trigModes.RADIANS) {
         return value;
@@ -268,49 +149,6 @@ function conditionFactory(tokens) {
     }
 }
 
-function conditionalExpressionFactory(tokens, expect, condition) {
-    return function(i) {
-        var conditionalExpression = new LogicalNot([]);
-        var nextCondition = new Condition(null, null, null);
-
-        i--;
-
-        while (true) {
-            if (condition(++i, (x) => x instanceof syntax.Expression)) {
-                expect(i, (x) => x instanceof syntax.Expression);
-
-                nextCondition.a = tokens[i];
-
-                expect(++i, (x) => x instanceof syntax.Comparator);
-
-                nextCondition.comparison = tokens[i];
-
-                expect(++i, (x) => x instanceof syntax.Expression);
-
-                nextCondition.b = tokens[i];
-
-                conditionalExpression.conditions.push(nextCondition);
-
-                nextCondition = new Condition(null, null, null);
-            } else {
-                i--;
-            }
-
-            if (condition(++i, (x) => x instanceof syntax.LogicalOperator)) {
-                conditionalExpression.conditions.push(tokens[i]);
-            } else {
-                break;
-            }
-        }
-
-        conditionalExpression.parse();
-
-        i--;
-
-        return {i, conditionalExpression};
-    }
-}
-
 export function parseProgram(program) {
     var tokens = syntax.tokenise(program);
     var additionalEnds = 0;
@@ -322,7 +160,6 @@ export function parseProgram(program) {
     for (var i = 0; i < tokens.length; i++) {
         var expect = expectFactory(tokens);
         var condition = conditionFactory(tokens);
-        var conditionalExpression = conditionalExpressionFactory(tokens, expect, condition);
 
         if (condition(i, (x) => x instanceof syntax.ExecutionLabel)) {
             programLabels[tokens[i].code] = parsedProgram.length;
@@ -354,19 +191,17 @@ export function parseProgram(program) {
 
             i++;
         } else if (condition(i, (x) => x instanceof syntax.Expression && x.getPrimaryIdentifier() != null)) { // Assignment
-            expect(++i, (x) => x instanceof syntax.Comparator && x.code == "=", (x) => x instanceof syntax.Expression);
+            expect(++i, (x) => x instanceof syntax.Assignment, (x) => x instanceof syntax.Expression);
 
             parsedProgram.push(new Command(commands.assign, [tokens[i - 1], tokens[++i]]));
 
             expect(++i, (x) => x instanceof syntax.StatementEnd);
         } else if (condition(i, (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "if")) { // If
-            var conditionalExpressionResult = conditionalExpression(++i);
+            expect(++i, (x) => x instanceof syntax.Expression);
 
-            i = conditionalExpressionResult.i;
+            parsedProgram.push(new OpeningCommand(commands.ifCondition, [tokens[i]]));
 
             expect(++i, (x) => x instanceof syntax.StatementEnd);
-
-            parsedProgram.push(new OpeningCommand(commands.ifCondition, [conditionalExpressionResult.conditionalExpression]));
         } else if (condition(i,
             (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "else",
             (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "if"
@@ -416,21 +251,17 @@ export function parseProgram(program) {
 
             repeatMode = true;
         } else if (condition(i, (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "while") && !repeatMode) { // While loop
-            var conditionalExpressionResult = conditionalExpression(++i);
+            expect(++i, (x) => x instanceof syntax.Expression);
 
-            i = conditionalExpressionResult.i;
+            parsedProgram.push(new OpeningCommand(commands.whileLoop, [tokens[i]]));
 
             expect(++i, (x) => x instanceof syntax.StatementEnd);
-
-            parsedProgram.push(new OpeningCommand(commands.whileLoop, [conditionalExpressionResult.conditionalExpression]));
         } else if (condition(i, (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "until") && !repeatMode) { // Until loop
-            var conditionalExpressionResult = conditionalExpression(++i);
+            expect(++i, (x) => x instanceof syntax.Expression);
 
-            i = conditionalExpressionResult.i;
+            parsedProgram.push(new OpeningCommand(commands.untilLoop, [tokens[i]]));
 
             expect(++i, (x) => x instanceof syntax.StatementEnd);
-
-            parsedProgram.push(new OpeningCommand(commands.untilLoop, [conditionalExpressionResult.conditionalExpression]));
         } else if (condition(i, (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "end")) { // Generic end
             parsedProgram.push(new ClosingCommand(commands.genericEnd));
 
@@ -450,23 +281,19 @@ export function parseProgram(program) {
 
             expect(i, (x) => x instanceof syntax.StatementEnd);
         } else if (condition(i, (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "while") && repeatMode) { // Repeat while end
-            var conditionalExpressionResult = conditionalExpression(++i);
+            expect(++i, (x) => x instanceof syntax.Expression);
 
-            i = conditionalExpressionResult.i;
+            parsedProgram.push(new ClosingCommand(commands.repeatWhileEnd, [tokens[i]]));
 
             expect(++i, (x) => x instanceof syntax.StatementEnd);
-
-            parsedProgram.push(new ClosingCommand(commands.repeatWhileEnd, [conditionalExpressionResult.conditionalExpression]));
 
             repeatMode = false;
         } else if (condition(i, (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "until") && repeatMode) { // Repeat until end
-            var conditionalExpressionResult = conditionalExpression(++i);
+            expect(++i, (x) => x instanceof syntax.Expression);
 
-            i = conditionalExpressionResult.i;
+            parsedProgram.push(new ClosingCommand(commands.repeatUntilEnd, [tokens[i]]));
 
             expect(++i, (x) => x instanceof syntax.StatementEnd);
-
-            parsedProgram.push(new ClosingCommand(commands.repeatUntilEnd, [conditionalExpressionResult.conditionalExpression]));
 
             repeatMode = false;
         } else if (condition(i, (x) => x instanceof syntax.Keyword && x.code.toLocaleLowerCase() == "loop")) { // Loop end

--- a/syntax.js
+++ b/syntax.js
@@ -380,8 +380,8 @@ export class Function extends Token {
             case "lower$": return String(this.expression.value).toLocaleLowerCase();
             case "upper$": return String(this.expression.value).toLocaleUpperCase();
             case "trim$": return String(this.expression.value).trim();
-            case "ltrim$": return String(this.expression.value).trimLeft();
-            case "rtrim$": return String(this.expression.value).trimRight();
+            case "ltrim$": return String(this.expression.value).trimStart();
+            case "rtrim$": return String(this.expression.value).trimEnd();
             case "chr$": return String.fromCharCode(this.expression.value);
             case "bin$": return Number(this.expression.value).toString(2);
             case "oct$": return Number(this.expression.value).toString(8);

--- a/syntax.js
+++ b/syntax.js
@@ -11,7 +11,7 @@ const RE_NUMERIC_LITERAL_OCT = /(?<![a-z_])0(?:o|O)[0-7]+/;
 const RE_NUMERIC_LITERAL_SCI = /(?:(?<=div|mod|and|or|xor|not)|(?<![a-z_][a-z0-9_]*))(?:[0-9]+\.?[0-9]*|[0-9]*\.?[0-9]+)(?:[eE][+-]?[0-9]+)?(?!\.)/;
 const RE_KEYWORD = /(?<![a-z_])(?<![a-z_][0-9]+)(?:print|input|goto|gosub|return|if|else|end|forward|for|to|step|next|break|continue|stop|repeat|while|until|loop|deg|rad|gon|turn|pos|cls|delay|bg|fg|move|draw|plot|stroke|fill|text|copy|restore|frame|getpixel|dim|push|pop|insert|remove|show|hide|forward|backward|left|right|penup|pendown|angle|note|play|rest|quiet|bpm|volume|envelope|speak|voice)/i;
 const RE_FUNCTION_NAME = /(?<![a-z_])(?<![a-z_][0-9]+)(?:sin|cos|tan|asin|acos|atan|log|ln|sqrt|round|floor|ceil|abs|asc|bin\$|oct\$|hex\$|bin|oct|hex|len|last|lower\$|upper\$|trim\$|ltrim\$|rtrim\$|chr\$)/i;
-const RE_CONSTANT = /(?<![a-z0-9_])(?:pi|e|phi|epoch|random|col|row|key|heading)(?![a-z0-9_])/i;
+const RE_CONSTANT = /(?<![a-z0-9_])(?:true|false|pi|e|phi|epoch|random|col|row|key|heading)(?![a-z0-9_])/i;
 const RE_ASSIGNMENT = /=/i;
 const RE_OPERATOR = /\+|-|\*|\/|\^|(?<![a-z_])(?:div|mod)(?![a-z_])|&|\||~|;/i;
 const RE_COMPARATOR = /!=|<=|>=|=|<|>/i;

--- a/syntax.js
+++ b/syntax.js
@@ -12,6 +12,7 @@ const RE_NUMERIC_LITERAL_SCI = /(?:(?<=div|mod|and|or|xor|not)|(?<![a-z_][a-z0-9
 const RE_KEYWORD = /(?<![a-z_])(?<![a-z_][0-9]+)(?:print|input|goto|gosub|return|if|else|end|forward|for|to|step|next|break|continue|stop|repeat|while|until|loop|deg|rad|gon|turn|pos|cls|delay|bg|fg|move|draw|plot|stroke|fill|text|copy|restore|frame|getpixel|dim|push|pop|insert|remove|show|hide|forward|backward|left|right|penup|pendown|angle|note|play|rest|quiet|bpm|volume|envelope|speak|voice)/i;
 const RE_FUNCTION_NAME = /(?<![a-z_])(?<![a-z_][0-9]+)(?:sin|cos|tan|asin|acos|atan|log|ln|sqrt|round|floor|ceil|abs|asc|bin\$|oct\$|hex\$|bin|oct|hex|len|last|lower\$|upper\$|trim\$|ltrim\$|rtrim\$|chr\$)/i;
 const RE_CONSTANT = /(?<![a-z0-9_])(?:pi|e|phi|epoch|random|col|row|key|heading)(?![a-z0-9_])/i;
+const RE_ASSIGNMENT = /=/i;
 const RE_OPERATOR = /\+|-|\*|\/|\^|(?<![a-z_])(?:div|mod)(?![a-z_])|&|\||~|;/i;
 const RE_COMPARATOR = /!=|<=|>=|=|<|>/i;
 const RE_LOGICAL_OPERATOR = /(?<![a-z_])(?<![a-z_][0-9]+)(?:and|or|xor|not)/i;
@@ -35,6 +36,7 @@ const RE_ALL = new RegExp([
     RE_KEYWORD.source,
     RE_FUNCTION_NAME.source,
     RE_CONSTANT.source,
+    RE_ASSIGNMENT.source,
     RE_OPERATOR.source,
     RE_COMPARATOR.source,
     RE_LOGICAL_OPERATOR.source,
@@ -153,9 +155,8 @@ export class ParameterSeperator extends Token {}
 export class StatementEnd extends Token {}
 export class ExecutionLabel extends Token {}
 export class Keyword extends Token {}
+export class Assignment extends Token {}
 export class Operator extends Token {}
-export class Comparator extends Token {}
-export class LogicalOperator extends Token {}
 export class StringConcat extends Token {}
 
 export class ExpressionBracket extends Token {
@@ -405,7 +406,7 @@ export class Function extends Token {
 
 export class StringConcatExpression extends Expression {
     constructor(tokens, lineNumber = null) {
-        super(tokens, new Operator(";"), SubtractionExpression, lineNumber);
+        super(tokens, new Operator(";"), LogicalOrExpression, lineNumber);
     }
 
     parse() {
@@ -539,6 +540,106 @@ export class StringConcatExpression extends Expression {
         }
 
         return value;
+    }
+}
+
+export class LogicalOrExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator("or"), LogicalXorExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return a || b ? 1 : 0;
+    }
+}
+
+export class LogicalXorExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator("xor"), LogicalAndExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return Boolean(a) ^ Boolean(b) ? 1 : 0;
+    }
+}
+
+export class LogicalAndExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator("and"), LogicalNotExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return a && b ? 1 : 0;
+    }
+}
+
+export class LogicalNotExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator("not"), EqualComparisonExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return !b ? 1 : 0;
+    }
+}
+
+export class EqualComparisonExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator("="), LessThanComparisonExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return basic.getValueComparative(a) == basic.getValueComparative(b) ? 1 : 0;
+    }
+}
+
+export class LessThanComparisonExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator("<"), GreaterThanComparisonExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return basic.getValueComparative(a) < basic.getValueComparative(b) ? 1 : 0;
+    }
+}
+
+export class GreaterThanComparisonExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator(">"), LessThanOrEqualComparisonExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return basic.getValueComparative(a) > basic.getValueComparative(b) ? 1 : 0;
+    }
+}
+
+export class LessThanOrEqualComparisonExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator("<="), GreaterThanOrEqualComparisonExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return basic.getValueComparative(a) <= basic.getValueComparative(b) ? 1 : 0;
+    }
+}
+
+export class GreaterThanOrEqualComparisonExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator(">="), NotEqualComparisonExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return basic.getValueComparative(a) >= basic.getValueComparative(b) ? 1 : 0;
+    }
+}
+
+export class NotEqualComparisonExpression extends Expression {
+    constructor(tokens, lineNumber = null) {
+        super(tokens, new Operator("!="), SubtractionExpression, lineNumber);
+    }
+
+    reduce(a, b) {
+        return basic.getValueComparative(a) != basic.getValueComparative(b) ? 1 : 0;
     }
 }
 
@@ -705,9 +806,6 @@ export function highlight(code, index, col, row) {
         var startOriginal = start;
         var codePos = 0;
 
-        // console.log(code, codeChars, start);
-        // debugger;
-
         for (var i = 0; i < codeChars.length; i++) {
             if (codePos > startOriginal) {
                 break;
@@ -806,6 +904,7 @@ export function tokeniseLine(code, lineNumber = null) {
     var expressionTokens = [];
     var commentMatch;
     var match;
+    var assignmentAllowed = true;
 
     if (commentMatch = RE_COMMENT.exec(code.replace(new RegExp(RE_STRING_LITERAL, "g"), function(matchedString) {
         return "\0".repeat(matchedString.length);
@@ -846,12 +945,16 @@ export function tokeniseLine(code, lineNumber = null) {
             computeExpressionTokens();
             tokens.push(new Keyword(lineSymbols[i], lineNumber));
 
+            assignmentAllowed = false;
+
             continue;
         }
 
         if (RE_STATEMENT_SEPERATOR.exec(lineSymbols[i])) {
             computeExpressionTokens();
             tokens.push(new StatementEnd(lineSymbols[i], lineNumber));
+
+            assignmentAllowed = true;
 
             continue;
         }
@@ -863,16 +966,11 @@ export function tokeniseLine(code, lineNumber = null) {
             continue;
         }
 
-        if (RE_COMPARATOR.exec(lineSymbols[i])) {
+        if (assignmentAllowed && RE_ASSIGNMENT.exec(lineSymbols[i])) {
             computeExpressionTokens();
-            tokens.push(new Comparator(lineSymbols[i], lineNumber));
+            tokens.push(new Assignment(lineSymbols[i], lineNumber));
 
-            continue;
-        }
-
-        if (RE_LOGICAL_OPERATOR.exec(lineSymbols[i])) {
-            computeExpressionTokens();
-            tokens.push(new LogicalOperator(lineSymbols[i], lineNumber));
+            assignmentAllowed = false;
 
             continue;
         }
@@ -894,7 +992,7 @@ export function tokeniseLine(code, lineNumber = null) {
             continue;
         }
 
-        if (RE_OPERATOR.exec(lineSymbols[i])) {
+        if (RE_OPERATOR.exec(lineSymbols[i]) || RE_COMPARATOR.exec(lineSymbols[i]) || RE_LOGICAL_OPERATOR.exec(lineSymbols[i])) {
             expressionTokens.push(new Operator(lineSymbols[i], lineNumber));
 
             continue;

--- a/syntax.js
+++ b/syntax.js
@@ -945,7 +945,9 @@ export function tokeniseLine(code, lineNumber = null) {
             computeExpressionTokens();
             tokens.push(new Keyword(lineSymbols[i], lineNumber));
 
-            assignmentAllowed = false;
+            if (lineSymbols[i] != "for") {
+                assignmentAllowed = false;
+            }
 
             continue;
         }


### PR DESCRIPTION
This PR fixes the usage of both logical operators and comparators by merging them into the main expression parsing and evaluation system, instead of treating them as a special type of expression. That way, for example, `5 = 5` will evaluate to `1`, and `4 = 5` will evaluate to `0`.

This opens up the possibilities for new syntax while preserving the behaviour of old programs:
* `if booleanCondition = 1` can now be rewritten as `if booleanCondition`
* Boolean logic expressions can be stored in variables and printed
* `true` and `false` constants are now provided, set to `1` and `0` respectively