### PR TITLE
Add shell command reference

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,6 +2,9 @@
 
 This reference guide contains a listing of all commands, functions, constants and operators that are available in atto which you can use to write your program. They are split up into different categories, as shown below.
 
+<h1 class="reference"><a href="/reference/shell.md" class="shell">Shell commands 🢒</a></h1>
+`list`, `run`, `renum`, `import`, `export`, `load` etc.
+
 <h1 class="reference"><a href="/reference/control.md" class="control">Control flow commands 🢒</a></h1>
 `goto`, `if`, `for`, `repeat`, `while`, `until` etc.
 

--- a/docs/reference/shell.md
+++ b/docs/reference/shell.md
@@ -1,0 +1,84 @@
+[Guide](/index.md) 🢒 [Command reference](/reference/index.md) 🢒 **Shell commands**
+
+## `help`
+```
+help
+```
+
+Opens this help guide to the side of the display.
+
+Keyboard shortcut: <kbd>f1</kbd>
+
+## `list`
+```
+list
+list linestart
+list linestart-lineend
+```
+
+Lists the program currently being edited. Specifying `linestart` will list the program starting at that line. Specifying a range (`linestart-lineend`) will list the program only for the lines in that range (such as `list 30-60` listing only lines 30 to 60).
+
+The arrow keys can then be used to go to a line shown on-screen for further editing.
+
+## `run`
+```
+run
+```
+
+Executes the program currently being edited.
+
+Keyboard shortcut: <kbd>f5</kbd>
+
+## `new`
+```
+new
+```
+
+Clears the program currently being edited so that a new program can be written.
+
+## `edit`
+```
+edit line
+```
+
+Brings up the line with the line number given as argument `line` so that it can be edited.
+
+## `renum`
+```
+renum
+```
+
+Renumbers all lines of the program currently being edited so that they are multiples of 10. This is used for adding extra lines in-between existing lines (for example, if a line needs to be added between line 10 and 11, then `renum` will renumber those lines to 10 and 20 so that a new line 15 can be added).
+
+## `export`
+```
+export
+export progname
+```
+
+Saves the program currently being edited to the host computer's storage as a `.atto` file. Specifying `progname` will save the program with the given name (so `export game` will save `game.atto`).
+
+Keyboard shortcut: <kbd>ctrl</kbd> + <kbd>s</kbd>
+
+## `import`
+```
+import
+```
+
+Loads a `.atto` program from the host computer's storage.
+
+Keyboard shortcut: <kbd>ctrl</kbd> + <kbd>o</kbd>
+
+## `share`
+```
+share
+```
+
+Copies a link to the host computer's clipboard that can be used to view and run the current program.
+
+## `load`
+```
+load
+```
+
+Loads the program that was edited the last time atto was used. This is useful if a program needs to be restored since the last session but was not saved using `export`.

--- a/style.css
+++ b/style.css
@@ -17,6 +17,9 @@
     --white: rgb(255, 255, 255);
     --keywordBlack: black;
     --keywordWhite: white;
+    --keyBackground: rgb(238, 238, 238);
+    --keyBorder: rgb(214, 214, 214);
+    --keyForeground: rgb(0, 0, 0);
 }
 
 * {
@@ -256,6 +259,20 @@ code span.statementSeperator {
     color: var(--darkBlue);
 }
 
+kbd {
+    margin-top: -2px;
+    margin-bottom: -2px;
+    padding: 2px;
+    padding-inline-start: 4px;
+    padding-inline-end: 4px;
+    font-family: "Brass Mono", monospace;
+    background-color: var(--keyBackground);
+    color: var(--keyForeground);
+    border: 2px solid var(--keyBorder);
+    box-shadow: 0 3px 0 2px var(--keyBorder);
+    border-radius: 5px;
+}
+
 blockquote {
     margin-inline-start: 0;
     margin-inline-end: 0;
@@ -300,6 +317,10 @@ h1.reference {
 
 h1.reference + p {
     margin-top: 0;
+}
+
+h1.reference a.shell {
+    color: var(--black);
 }
 
 h1.reference a.control {


### PR DESCRIPTION
This includes commands such as `list`, `edit`, `import`, `export` etc. which can't be used inside programs; only the shell. A new styling for the `<kbd>` element was also added so that keyboard shortcuts for these commands can be displayed too.