### PR TITLE
Fix program inputs still being retained after `new` and `run`

### DIFF
--- a/basic.js
+++ b/basic.js
@@ -1102,6 +1102,7 @@ window.addEventListener("keydown", function(event) {
 
     if (event.key == "F5") {
         hid.unfocusInput();
+        hid.clearProgramInputs();
 
         try {
             parseProgram(editingProgram);

--- a/basic.js
+++ b/basic.js
@@ -940,6 +940,8 @@ export function processCommand(value, movementOnly) {
     if (command == "new") {
         editingProgram = [];
 
+        hid.clearProgramInputs();
+
         term.print("Created new program\n");
         autosave();
         hid.startProgramInput();
@@ -948,6 +950,8 @@ export function processCommand(value, movementOnly) {
     }
 
     if (command == "run") {
+        hid.clearProgramInputs();
+
         try {
             parseProgram(editingProgram);
         } catch (e) {

--- a/hid.js
+++ b/hid.js
@@ -325,6 +325,10 @@ export function startProgramInput(lineValue = "", immediateEdit = true, relative
     }
 }
 
+export function clearProgramInputs() {
+    programInputs = [];
+}
+
 export function getFocusedInput() {
     if (currentInput != null) {
         return currentInput;

--- a/term.js
+++ b/term.js
@@ -100,8 +100,6 @@ export function clear() {
 export function print(text, notifyHid = true, wrap = true) {
     text = Array.from(text);
 
-    var textCharsToDraw = [];
-
     for (var i = 0; i < text.length; i++) {
         switch (text[i]) {
             case "\n":
@@ -134,8 +132,6 @@ export function print(text, notifyHid = true, wrap = true) {
                 break;
         }
     }
-
-    // textCharsToDraw.forEach((charArgs) => canvas.drawText(...charArgs));
 
     if (notifyHid) {
         hid.log(text);


### PR DESCRIPTION
Using the arrow keys to navigate to the previous and next listed editing lines becomes unhelpful in certain scenarios, such as when creating a new program (clearing the current program), in addition to running a program. This PR fixes the behaviour by clearing the editing line scrollback data to prevent old lines from being called up again, which can become confusing in certain cases.